### PR TITLE
Add Admin Mode (teacher login) — restrict signup/unregister to teachers

### DIFF
--- a/src/teachers.json
+++ b/src/teachers.json
@@ -1,0 +1,8 @@
+{
+  "teachers": [
+    {
+      "username": "teacher",
+      "password": "teachpass"
+    }
+  ]
+}


### PR DESCRIPTION
Implements simple admin login stored in `src/teachers.json` and requires a token (`X-Admin-Token`) for `POST /activities/{activity}/signup` and `DELETE /activities/{activity}/unregister`.

- Adds `/admin/login` endpoint returning a token for teacher accounts defined in `src/teachers.json`.
- Stores active sessions in-memory (UUID tokens).
- Sample teacher account added: username `teacher`, password `teachpass`.

This addresses issue #5 (Admin Mode) by ensuring only teachers can register/unregister students.
